### PR TITLE
Fix schema for multi expression ticket test case

### DIFF
--- a/compliance_suite/config/tests.py
+++ b/compliance_suite/config/tests.py
@@ -915,7 +915,7 @@ TESTS_DICT = {
                         + "request format",
                     "summary_skip": "'Expression Ticket - Filetypes Match' "
                         + "skipped",
-                    "schema_func": sf.schema_require_matching_search_params,
+                    "schema_file": c.SCHEMA_FILE_TICKET,
                     "request_params_func": pf.add_format_from_retrieved_settings
                 }
             ]


### PR DESCRIPTION
The test case `Expression Ticket - Filetype Matches` validates responses on the `RNAGetReqSearchParams` schema. This might return an error as it expects a required `id` attribute while the `RNAGetTicket` object does not have it.