### PR TITLE
Fix/handle ssl errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - '3.6'
-  - '3.7'    
+  - '3.7'
 install:
   - python -m pip install --upgrade pip
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - '3.6'
-  - '3.7'
+  - '3.7'    
 install:
   - python -m pip install --upgrade pip
   - python setup.py install
@@ -13,6 +13,9 @@ script:
   - pytest --cov=compliance_suite/ --cov-report=term-missing unittests/
 after_success:
   - coveralls
+  - echo "Checking REQUESTS_CA_BUNDLE"
+  - ls $REQUESTS_CA_BUNDLE
+  - cat $REQUESTS_CA_BUNDLE
   - bash ./scripts/deploy-gh-pages.sh
 after_script:
   - kill %1
@@ -20,4 +23,5 @@ env:
   global:
   - GH_USER: ga4gh-rnaseq
   - GH_REPO: rnaget-compliance-suite
+  - REQUESTS_CA_BUNDLE: ${TRAVIS_BUILD_DIR}/certs/cabundle.pem
   - secure: J+a6OkJZRU5m/qy9G3AMdmPjtuegdAhCypaoa7lk9Vs8zVoY1+ImEfZEVC1nLZQgaCmmUvYqUHqRj4SZ+0Vv4FaGkqsfX4Ad5/ymVF4WnkkC2mr6si4jzOpZN+7OpHM0z5gY6X3bir3Jlx/WB/I3IDCjysOUfOLw9X3nD9Cfvq108KjMpR5RM76mBn23XNubyZJ8BX36YaowAEVpml83VyEA3QAwd37ejB3tuUigSk1i9PWRnMqKdrY6fbM6DuTnFiI1ZW1KEvvr5AHY61XsatSLFIAg8RH2suBduneLdxbkGPW9jfvGt+l/G73STagIcuv69jOQh/rIPxrlSy8JPt3hbWRS6eaeZOidtoURofTYm2CEFFO8WOsagKCyAirUYBHKCTdN518tuR6t++5gPfQQB97l/n+4C4WdKDhPYP1Lto+YXjyumBE0E/JRSTTsum4kcps8SSjJtHTn86ZeI0jBIfkLEMjNc7/dQog5hCD7viH+b+GTqVuz70CxzrZut5CJdBWGj2hPwSbkbveVi50Ccp/eodh7uUZZO6Mptd1HF4+ad53XBEjaxds8Dm1cVCXH+3gJajAAYb99mPZWjEl1h/Iho6H9r/wwrTlfMHVPGBe42DtQpFfHfOzgz4NOgqR7lyP7sLEEd6quTn7RCMMsdXukJgGIQvMHKaKy3Cc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ script:
   - pytest --cov=compliance_suite/ --cov-report=term-missing unittests/
 after_success:
   - coveralls
-  - echo "Checking REQUESTS_CA_BUNDLE"
-  - ls $REQUESTS_CA_BUNDLE
-  - cat $REQUESTS_CA_BUNDLE
   - bash ./scripts/deploy-gh-pages.sh
 after_script:
   - kill %1

--- a/compliance_suite/elements/case.py
+++ b/compliance_suite/elements/case.py
@@ -58,7 +58,7 @@ class Case(Element):
                if "summary_skip" in self.case_params.keys() else "",
             2: "An unhandled exception occurred"
         }
-        self.summary = self.set_summary()
+        self.set_summary()
 
         self.error_message = None
         self.audit = []

--- a/compliance_suite/elements/component.py
+++ b/compliance_suite/elements/component.py
@@ -9,6 +9,7 @@ attachments. A component holds multiple Cases.
 """
 
 from compliance_suite.elements.element import Element
+from compliance_suite.elements.api_case import APICase
 import json
 
 class Component(Element):
@@ -35,7 +36,8 @@ class Component(Element):
         self.test_params = test_params
         self.test = test
         self.runner = runner
-        self.case_class = None
+        self.case_class = APICase
+        self.test_cases = []
     
     def create_test_cases(self):
         """Create all test cases from params

--- a/compliance_suite/exceptions/test_status_exception.py
+++ b/compliance_suite/exceptions/test_status_exception.py
@@ -15,6 +15,11 @@ class TestStatusException(Exception):
     
     pass
 
+class NoResponseException(TestStatusException):
+    """Raised when no response was received from the endpoint"""
+
+    pass
+
 class MediaTypeException(TestStatusException):
     """Raised when response content type does not match accepted media types"""
 


### PR DESCRIPTION
Safely fails API test cases that throw an error due to SSL verification failure. Also added the `REQUESTS_CA_BUNDLE` environment variable so that the CRG server can pass tests.

We can merge this into develop, then, once closed, merge into master